### PR TITLE
feature: Adjust parameter filtering logic in analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,9 +10,10 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.13.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
     <PackageVersion Include="xunit.v3" Version="2.0.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
   </ItemGroup>

--- a/src/LoggerUsage/Analyzers/LogMethodAnalyzer.cs
+++ b/src/LoggerUsage/Analyzers/LogMethodAnalyzer.cs
@@ -7,8 +7,10 @@ using Microsoft.Extensions.Logging;
 namespace LoggerUsage.Analyzers
 {
 
-    internal class LogMethodAnalyzer : ILoggerUsageAnalyzer
+    internal class LogMethodAnalyzer(ILoggerFactory loggerFactory) : ILoggerUsageAnalyzer
     {
+        private readonly ILogger<LogMethodAnalyzer> _logger = loggerFactory.CreateLogger<LogMethodAnalyzer>();
+
         public IEnumerable<LoggerUsageInfo> Analyze(LoggingTypes loggingTypes, SyntaxNode root, SemanticModel semanticModel)
         {
             var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>();

--- a/src/LoggerUsage/LoggerUsage.csproj
+++ b/src/LoggerUsage/LoggerUsage.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/LoggerUsage/LoggerUsageExtractor.cs
+++ b/src/LoggerUsage/LoggerUsageExtractor.cs
@@ -9,19 +9,20 @@ namespace LoggerUsage;
 
 public class LoggerUsageExtractor
 {
-    private static readonly ILoggerUsageAnalyzer[] _analyzers =
-    {
-        new LogMethodAnalyzer(),
-        new LoggerMessageAttributeAnalyzer()
-    };
+    private readonly ILoggerUsageAnalyzer[] _analyzers;
     private readonly ILogger<LoggerUsageExtractor> _logger;
 
-    public LoggerUsageExtractor(ILogger<LoggerUsageExtractor> logger)
+    public LoggerUsageExtractor(ILoggerFactory loggerFactory)
     {
-        _logger = logger;
+        _logger = loggerFactory.CreateLogger<LoggerUsageExtractor>();
+        _analyzers =
+        [
+            new LogMethodAnalyzer(loggerFactory),
+            new LoggerMessageAttributeAnalyzer(loggerFactory)
+        ];
     }
 
-    public LoggerUsageExtractor() : this(NullLogger<LoggerUsageExtractor>.Instance)
+    public LoggerUsageExtractor() : this(NullLoggerFactory.Instance)
     {
     }
 

--- a/src/LoggerUsage/LoggingTypes.cs
+++ b/src/LoggerUsage/LoggingTypes.cs
@@ -9,6 +9,7 @@ namespace LoggerUsage
         {
             ILogger = loggerInterface;
             LoggerMessageAttribute = compilation.GetTypeByMetadataName(typeof(LoggerMessageAttribute).FullName!)!;
+            LogPropertiesAttribute = compilation.GetTypeByMetadataName(typeof(LogPropertiesAttribute).FullName!)!;
             EventId = compilation.GetTypeByMetadataName(typeof(EventId).FullName!)!;
             LogLevel = compilation.GetTypeByMetadataName(typeof(LogLevel).FullName!)!;
             LoggerExtensions = compilation.GetTypeByMetadataName(typeof(LoggerExtensions).FullName!)!;
@@ -25,6 +26,7 @@ namespace LoggerUsage
         public INamedTypeSymbol LoggerExtensions { get; }
         public INamedTypeSymbol Exception { get; }
         public IArrayTypeSymbol ObjectNullableArray { get; }
+        public INamedTypeSymbol LogPropertiesAttribute { get; }
 
         public LoggerExtensionModeler LoggerExtensionModeler { get; }
     }

--- a/src/LoggerUsage/SymbolExtensions.cs
+++ b/src/LoggerUsage/SymbolExtensions.cs
@@ -9,4 +9,34 @@ public static class SymbolExtensions
         .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
     public static string ToPrettyDisplayString(this ITypeSymbol typeSymbol) => typeSymbol.ToDisplayString(_symbolDisplayFormat);
+
+    internal static bool IsLoggerInterface(this ITypeSymbol typeSymbol, LoggingTypes loggingTypes)
+    {
+        if (loggingTypes.ILogger.Equals(typeSymbol, SymbolEqualityComparer.Default))
+        {
+            return true;
+        }
+
+        if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
+        {
+            return namedTypeSymbol.AllInterfaces.Any(i => i.Equals(loggingTypes.ILogger, SymbolEqualityComparer.Default));
+        }
+
+        return false;
+    }
+
+    internal static bool IsException(this ITypeSymbol typeSymbol, LoggingTypes loggingTypes)
+    {
+        if (loggingTypes.Exception.Equals(typeSymbol, SymbolEqualityComparer.Default))
+        {
+            return true;
+        }
+
+        if (typeSymbol.BaseType is not null)
+        {
+            return IsException(typeSymbol.BaseType, loggingTypes);
+        }
+
+        return false;
+    }
 }

--- a/test/LoggerUsage.Tests/TestUtils.cs
+++ b/test/LoggerUsage.Tests/TestUtils.cs
@@ -12,6 +12,7 @@ internal static class TestUtils
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode);
         var references = await ReferenceAssemblies.Net.Net90.ResolveAsync(LanguageNames.CSharp, default);
         references = references.Add(MetadataReference.CreateFromFile(typeof(ILogger).Assembly.Location));
+        references = references.Add(MetadataReference.CreateFromFile(typeof(LogPropertiesAttribute).Assembly.Location));
         var compilation = CSharpCompilation.Create(
             "TestAssembly",
             [syntaxTree],


### PR DESCRIPTION
Introduce ILogger usage in LogMethodAnalyzer and LoggerMessageAttributeAnalyzer for improved traceability. 
Update Microsoft.Extensions.Logging.Abstractions and add Microsoft.Extensions.Telemetry.Abstractions to dependencies. 
Adjust parameter filtering logic in analyzers and update related tests.