### PR TITLE
chore: Add Dependabot config for weekly NuGet dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Introduce .github/dependabot.yml to automate checking for NuGet package updates on a weekly schedule, improving dependency management and security.