### PR TITLE
Adds LoggerMessage.Define analyzer support

### DIFF
--- a/src/LoggerUsage/Analyzers/LoggerMessageDefineAnalyzer.cs
+++ b/src/LoggerUsage/Analyzers/LoggerMessageDefineAnalyzer.cs
@@ -1,0 +1,208 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using LoggerUsage.Models;
+using Microsoft.Extensions.Logging;
+
+namespace LoggerUsage.Analyzers
+{
+    internal class LoggerMessageDefineAnalyzer(ILoggerFactory loggerFactory) : ILoggerUsageAnalyzer
+    {
+        private readonly ILogger<LoggerMessageDefineAnalyzer> _logger = loggerFactory.CreateLogger<LoggerMessageDefineAnalyzer>();
+
+        public IEnumerable<LoggerUsageInfo> Analyze(LoggingTypes loggingTypes, SyntaxNode root, SemanticModel semanticModel)
+        {
+            var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>();
+            foreach (var invocation in invocations)
+            {
+                if (semanticModel.GetOperation(invocation) is not IInvocationOperation operation)
+                    continue;
+
+                if (!operation.TargetMethod.ContainingType.Equals(loggingTypes.LoggerMessage, SymbolEqualityComparer.Default)
+                    || !operation.TargetMethod.Name.Equals(nameof(LoggerMessage.Define)))
+                    continue;
+
+                yield return ExtractLoggerMessageDefineUsage(operation, loggingTypes, invocation);
+            }
+        }
+
+        private static LoggerUsageInfo ExtractLoggerMessageDefineUsage(IInvocationOperation operation, LoggingTypes loggingTypes, InvocationExpressionSyntax invocation)
+        {
+            var usage = new LoggerUsageInfo
+            {
+                MethodName = operation.TargetMethod.Name,
+                MethodType = LoggerUsageMethodType.LoggerMessageDefine,
+                Location = new MethodCallLocation
+                {
+                    StartLineNumber = invocation.GetLocation().GetLineSpan().StartLinePosition.Line,
+                    EndLineNumber = invocation.GetLocation().GetLineSpan().EndLinePosition.Line,
+                    FilePath = invocation.GetLocation().SourceTree!.FilePath
+                },
+            };
+
+            if (TryExtractLogLevel(operation, loggingTypes, out var logLevel))
+            {
+                usage.LogLevel = logLevel;
+            }
+
+            if (TryExtractEventId(operation, loggingTypes, out var eventId))
+            {
+                usage.EventId = eventId;
+            }
+
+            if (TryExtractMessageTemplate(operation, out var messageTemplate))
+            {
+                usage.MessageTemplate = messageTemplate;
+                usage.MessageParameters = ExtractMessageParametersFromGenericTypes(operation, messageTemplate);
+            }
+
+            return usage;
+        }
+
+        private static bool TryExtractLogLevel(IInvocationOperation operation, LoggingTypes loggingTypes, out LogLevel logLevel)
+        {
+            // LogLevel is typically the first parameter in LoggerMessage.Define
+            if (operation.Arguments.Length > 0)
+            {
+                var logLevelArg = operation.Arguments[0].Value;
+                if (logLevelArg is IFieldReferenceOperation fieldRef && fieldRef.ConstantValue.HasValue)
+                {
+                    logLevel = (LogLevel)fieldRef.ConstantValue.Value!;
+                    return true;
+                }
+            }
+
+            logLevel = default;
+            return false;
+        }
+        private static bool TryExtractEventId(IInvocationOperation operation, LoggingTypes loggingTypes, out EventIdBase eventId)
+        {
+            // EventId is typically the second parameter in LoggerMessage.Define
+            if (operation.Arguments.Length > 1)
+            {
+                var eventIdArg = operation.Arguments[1].Value.UnwrapConversion();
+
+                // Handle EventId constructor
+                if (eventIdArg is IObjectCreationOperation objectCreation &&
+                    objectCreation.Type?.Name == nameof(EventId))
+                {
+                    ConstantOrReference id = ConstantOrReference.Missing;
+                    ConstantOrReference name = ConstantOrReference.Missing;
+
+                    if (objectCreation.Arguments.Length > 0)
+                    {
+                        if (objectCreation.Arguments[0].Value.ConstantValue.Value is int idValue)
+                        {
+                            id = ConstantOrReference.Constant(idValue);
+                        }
+                        else
+                        {
+                            id = new ConstantOrReference(
+                                objectCreation.Arguments[0].Value.Kind.ToString(),
+                                objectCreation.Arguments[0].Value.Syntax.ToString()
+                            );
+                        }
+                    }
+                    if (objectCreation.Arguments.Length > 1)
+                    {
+                        if (objectCreation.Arguments[1].Value.ConstantValue.HasValue)
+                        {
+                            var nameValue = objectCreation.Arguments[1].Value.ConstantValue.Value;
+                            if (nameValue != null)
+                            {
+                                name = ConstantOrReference.Constant(nameValue);
+                            }
+                        }
+                        else
+                        {
+                            name = new ConstantOrReference(
+                                objectCreation.Arguments[1].Value.Kind.ToString(),
+                                objectCreation.Arguments[1].Value.Syntax.ToString()
+                            );
+                        }
+                    }
+
+                    eventId = new EventIdDetails(id, name);
+                    return true;
+                }
+                else if (eventIdArg.Kind is OperationKind.DefaultValue)
+                {
+                    eventId = default!;
+                    return false;
+                }
+                else if (eventIdArg is ILiteralOperation literalOperation)
+                {
+                    if (literalOperation.ConstantValue.HasValue)
+                    {
+                        eventId = new EventIdDetails(ConstantOrReference.Constant(literalOperation.ConstantValue.Value!), ConstantOrReference.Missing);
+                        return true;
+                    }
+                    else
+                    {
+                        eventId = new EventIdRef(
+                            literalOperation.Kind.ToString(),
+                            literalOperation.Syntax.ToString()
+                        );
+                        return true;
+                    }
+                }
+                // Handle direct EventId value or reference
+                else if (eventIdArg.ConstantValue.HasValue)
+                {
+                    eventId = new EventIdDetails(ConstantOrReference.Constant(eventIdArg.ConstantValue.Value!), ConstantOrReference.Missing);
+                    return true;
+                }
+                else
+                {
+                    eventId = new EventIdRef(
+                        eventIdArg.Kind.ToString(),
+                        eventIdArg.Syntax.ToString()
+                    );
+                    return true;
+                }
+            }
+
+            eventId = default!;
+            return false;
+        }
+
+        private static bool TryExtractMessageTemplate(IInvocationOperation operation, out string messageTemplate)
+        {
+            // Message template is typically the third parameter in LoggerMessage.Define
+            if (operation.Arguments.Length > 2)
+            {
+                var messageArg = operation.Arguments[2].Value;
+                if (messageArg.ConstantValue.HasValue)
+                {
+                    messageTemplate = messageArg.ConstantValue.Value?.ToString() ?? string.Empty;
+                    return true;
+                }
+            }
+
+            messageTemplate = string.Empty;
+            return false;
+        }
+
+        private static List<MessageParameter> ExtractMessageParametersFromGenericTypes(IInvocationOperation operation, string messageTemplate)
+        {
+            var messageParameters = new List<MessageParameter>();
+
+            // LoggerMessage.Define<T1, T2, ...> - extract generic type arguments
+            if (operation.TargetMethod.IsGenericMethod)
+            {
+                var formatter = new LogValuesFormatter(messageTemplate);
+                var typeArguments = operation.TargetMethod.TypeArguments;
+                for (int i = 0; i < typeArguments.Length && i < formatter.ValueNames.Count; i++)
+                {
+                    messageParameters.Add(new MessageParameter(
+                        Name: formatter.ValueNames[i],
+                        Type: typeArguments[i].ToPrettyDisplayString(),
+                        Kind: null
+                    ));
+                }
+            }
+
+            return messageParameters;
+        }
+    }
+}

--- a/src/LoggerUsage/LoggerUsageExtractor.cs
+++ b/src/LoggerUsage/LoggerUsageExtractor.cs
@@ -15,11 +15,11 @@ public class LoggerUsageExtractor
 
     public LoggerUsageExtractor(ILoggerFactory loggerFactory)
     {
-        _logger = loggerFactory.CreateLogger<LoggerUsageExtractor>();
-        _analyzers =
+        _logger = loggerFactory.CreateLogger<LoggerUsageExtractor>();        _analyzers =
         [
             new LogMethodAnalyzer(loggerFactory),
-            new LoggerMessageAttributeAnalyzer(loggerFactory)
+            new LoggerMessageAttributeAnalyzer(loggerFactory),
+            new LoggerMessageDefineAnalyzer(loggerFactory)
         ];
     }
 

--- a/src/LoggerUsage/LoggingTypes.cs
+++ b/src/LoggerUsage/LoggingTypes.cs
@@ -13,6 +13,7 @@ namespace LoggerUsage
             EventId = compilation.GetTypeByMetadataName(typeof(EventId).FullName!)!;
             LogLevel = compilation.GetTypeByMetadataName(typeof(LogLevel).FullName!)!;
             LoggerExtensions = compilation.GetTypeByMetadataName(typeof(LoggerExtensions).FullName!)!;
+            LoggerMessage = compilation.GetTypeByMetadataName(typeof(LoggerMessage).FullName!)!;
             Exception = compilation.GetTypeByMetadataName(typeof(System.Exception).FullName!)!;
             LoggerExtensionModeler = new(this);
             ObjectNullableArray = compilation.CreateArrayTypeSymbol(compilation.GetSpecialType(SpecialType.System_Object), 
@@ -24,6 +25,7 @@ namespace LoggerUsage
         public INamedTypeSymbol EventId { get; }
         public INamedTypeSymbol LogLevel { get; }
         public INamedTypeSymbol LoggerExtensions { get; }
+        public INamedTypeSymbol LoggerMessage { get; }
         public INamedTypeSymbol Exception { get; }
         public IArrayTypeSymbol ObjectNullableArray { get; }
         public INamedTypeSymbol LogPropertiesAttribute { get; }

--- a/src/LoggerUsage/Models/LoggerUsageMethodType.cs
+++ b/src/LoggerUsage/Models/LoggerUsageMethodType.cs
@@ -6,5 +6,7 @@ public enum LoggerUsageMethodType
 
     LoggerExtensions,
 
-    LoggerMessageAttribute
+    LoggerMessageAttribute,
+
+    LoggerMessageDefine
 }

--- a/test/LoggerUsage.Tests/LoggerMessageDefineTests.cs
+++ b/test/LoggerUsage.Tests/LoggerMessageDefineTests.cs
@@ -158,7 +158,9 @@ public class TestClass
         Assert.NotNull(loggerUsages);
         Assert.Single(loggerUsages.Results);
         Assert.Equal(expectedMessage, loggerUsages.Results[0].MessageTemplate);
-    }    public static TheoryData<string, string, List<MessageParameter>> LoggerMessageDefineParameterScenarios() => new()
+    }
+
+    public static TheoryData<string, string, List<MessageParameter>> LoggerMessageDefineParameterScenarios() => new()
     {
         // No parameters
         { "", "System startup completed", [] },
@@ -170,7 +172,9 @@ public class TestClass
         { "<int, System.DateTime>", "Order {OrderId} processed at {ProcessedTime}", [new("OrderId", "int", null), new("ProcessedTime", "System.DateTime", null)] },
         // Complex types
         { "<System.Guid, string, double>", "Transaction {Id} for {Customer} amount {Amount}", [new("Id", "System.Guid", null), new("Customer", "string", null), new("Amount", "double", null)] },
-    };    [Theory]
+    };
+
+    [Theory]
     [MemberData(nameof(LoggerMessageDefineParameterScenarios))]
     public async Task LoggerMessageDefine_Parameter_Scenarios(string genericTypes, string messageTemplate, List<MessageParameter> expectedParameters)
     {

--- a/test/LoggerUsage.Tests/LoggerMessageDefineTests.cs
+++ b/test/LoggerUsage.Tests/LoggerMessageDefineTests.cs
@@ -1,0 +1,233 @@
+using LoggerUsage.Models;
+using Microsoft.Extensions.Logging;
+
+namespace LoggerUsage.Tests;
+
+public class LoggerMessageDefineTests
+{
+    [Fact]
+    public async Task BasicTest()
+    {
+        // Arrange
+        var code = @"#nullable enable
+using Microsoft.Extensions.Logging;
+using System;
+namespace TestNamespace;
+
+public class TestClass
+{
+    private static readonly Action<ILogger, string, Exception?> _logUserCreated = 
+        LoggerMessage.Define<string>(LogLevel.Information, new EventId(1, ""UserCreated""), ""User {Name} was created"");
+}";
+        var compilation = await TestUtils.CreateCompilationAsync(code);
+        var extractor = new LoggerUsageExtractor();
+
+        // Act
+        var loggerUsages = extractor.ExtractLoggerUsages(compilation);
+
+        // Assert
+        Assert.NotNull(loggerUsages);
+        Assert.Single(loggerUsages.Results);
+        var result = loggerUsages.Results[0];
+        Assert.Equal("Define", result.MethodName);
+        Assert.Equal(LoggerUsageMethodType.LoggerMessageDefine, result.MethodType);
+        Assert.Equal(LogLevel.Information, result.LogLevel);
+        Assert.Equal("User {Name} was created", result.MessageTemplate);
+        Assert.NotNull(result.EventId);
+    }
+
+    public static TheoryData<string, int?, string?> LoggerMessageDefineEventIdScenarios() => new()
+    {
+        { "new EventId(1, \"UserCreated\")", 1, "UserCreated" },
+        { "new EventId(100, \"OrderProcessed\")", 100, "OrderProcessed" },
+        { "new EventId(0)", 0, null },
+        { "new EventId(-1)", -1, null },
+        { "1", 1, null },
+    };
+
+    [Theory]
+    [MemberData(nameof(LoggerMessageDefineEventIdScenarios))]
+    public async Task LoggerMessageDefine_EventId_Scenarios(string eventIdArg, int? expectedId, string? expectedName)
+    {
+        // Arrange
+        var code = $@"#nullable enable
+using Microsoft.Extensions.Logging;
+using System;
+namespace TestNamespace;
+
+public class TestClass
+{{
+    private static readonly Action<ILogger, string, Exception?> _logAction = 
+        LoggerMessage.Define<string>(LogLevel.Information, {eventIdArg}, ""Test message {{Name}}"");
+}}";
+
+        var compilation = await TestUtils.CreateCompilationAsync(code);
+        var extractor = new LoggerUsageExtractor();
+
+        // Act
+        var loggerUsages = extractor.ExtractLoggerUsages(compilation);
+
+        // Assert
+        Assert.NotNull(loggerUsages);
+        Assert.Single(loggerUsages.Results);
+        var usage = loggerUsages.Results[0];
+        Assert.NotNull(usage.EventId);
+
+        var details = Assert.IsType<EventIdDetails>(usage.EventId);
+        if (expectedId is not null)
+            Assert.Equal(ConstantOrReference.Constant(expectedId), details.Id);
+        else
+            Assert.Same(ConstantOrReference.Missing, details.Id);
+
+        if (expectedName is not null)
+            Assert.Equal(ConstantOrReference.Constant(expectedName), details.Name);
+        else
+            Assert.Same(ConstantOrReference.Missing, details.Name);
+    }
+
+    public static TheoryData<string, LogLevel> LoggerMessageDefineLogLevelScenarios() => new()
+    {
+        { "LogLevel.Information", LogLevel.Information },
+        { "LogLevel.Warning", LogLevel.Warning },
+        { "LogLevel.Error", LogLevel.Error },
+        { "LogLevel.Critical", LogLevel.Critical },
+        { "LogLevel.Trace", LogLevel.Trace },
+        { "LogLevel.Debug", LogLevel.Debug },
+        { "LogLevel.None", LogLevel.None },
+    };
+
+    [Theory]
+    [MemberData(nameof(LoggerMessageDefineLogLevelScenarios))]
+    public async Task LoggerMessageDefine_LogLevel_Scenarios(string logLevelArg, LogLevel expectedLogLevel)
+    {
+        // Arrange
+        var code = $@"#nullable enable
+using Microsoft.Extensions.Logging;
+using System;
+namespace TestNamespace;
+
+public class TestClass
+{{
+    private static readonly Action<ILogger, Exception?> _logAction = 
+        LoggerMessage.Define({logLevelArg}, new EventId(1), ""Test message"");
+}}";
+        var compilation = await TestUtils.CreateCompilationAsync(code);
+        var extractor = new LoggerUsageExtractor();
+
+        // Act
+        var loggerUsages = extractor.ExtractLoggerUsages(compilation);
+
+        // Assert
+        Assert.NotNull(loggerUsages);
+        Assert.Single(loggerUsages.Results);
+        Assert.Equal(expectedLogLevel, loggerUsages.Results[0].LogLevel);
+    }
+
+    public static TheoryData<string, string> LoggerMessageDefineMessageScenarios() => new()
+    {
+        { "\"Test message\"", "Test message" },
+        { "\"User {Name} was created\"", "User {Name} was created" },
+        { "\"Order {OrderId} was processed\"", "Order {OrderId} was processed" },
+        { "\"User {UserName} logged in from IP {IpAddress}\"", "User {UserName} logged in from IP {IpAddress}" },
+        { "\"System startup completed\"", "System startup completed" },
+        { "\"\"", "" },
+    };
+
+    [Theory]
+    [MemberData(nameof(LoggerMessageDefineMessageScenarios))]
+    public async Task LoggerMessageDefine_Message_Scenarios(string messageArg, string expectedMessage)
+    {
+        // Arrange
+        var code = $@"#nullable enable
+using Microsoft.Extensions.Logging;
+using System;
+namespace TestNamespace;
+
+public class TestClass
+{{
+    private static readonly Action<ILogger, Exception?> _logAction = 
+        LoggerMessage.Define(LogLevel.Information, new EventId(1), {messageArg});
+}}";
+        var compilation = await TestUtils.CreateCompilationAsync(code);
+        var extractor = new LoggerUsageExtractor();
+
+        // Act
+        var loggerUsages = extractor.ExtractLoggerUsages(compilation);
+
+        // Assert
+        Assert.NotNull(loggerUsages);
+        Assert.Single(loggerUsages.Results);
+        Assert.Equal(expectedMessage, loggerUsages.Results[0].MessageTemplate);
+    }    public static TheoryData<string, string, List<MessageParameter>> LoggerMessageDefineParameterScenarios() => new()
+    {
+        // No parameters
+        { "", "System startup completed", [] },
+        // Single parameter
+        { "<string>", "User {Name} was created", [new("Name", "string", null)] },
+        // Multiple parameters
+        { "<string, int>", "User {UserName} logged in from IP {IpAddress}", [new("UserName", "string", null), new("IpAddress", "int", null)] },
+        // Different types
+        { "<int, System.DateTime>", "Order {OrderId} processed at {ProcessedTime}", [new("OrderId", "int", null), new("ProcessedTime", "System.DateTime", null)] },
+        // Complex types
+        { "<System.Guid, string, double>", "Transaction {Id} for {Customer} amount {Amount}", [new("Id", "System.Guid", null), new("Customer", "string", null), new("Amount", "double", null)] },
+    };    [Theory]
+    [MemberData(nameof(LoggerMessageDefineParameterScenarios))]
+    public async Task LoggerMessageDefine_Parameter_Scenarios(string genericTypes, string messageTemplate, List<MessageParameter> expectedParameters)
+    {
+        // Generate the correct Action delegate type based on generic parameters
+        var actionType = GenerateActionType(genericTypes);
+        
+        // Arrange
+        var code = $@"#nullable enable
+using Microsoft.Extensions.Logging;
+using System;
+namespace TestNamespace;
+
+public class TestClass
+{{
+    private static readonly {actionType} _logAction = 
+        LoggerMessage.Define{genericTypes}(LogLevel.Information, new EventId(1), ""{messageTemplate}"");
+}}";
+        var compilation = await TestUtils.CreateCompilationAsync(code);
+        var extractor = new LoggerUsageExtractor();
+
+        // Act
+        var loggerUsages = extractor.ExtractLoggerUsages(compilation);
+
+        // Assert
+        Assert.NotNull(loggerUsages);
+        Assert.Single(loggerUsages.Results);
+        var usage = loggerUsages.Results[0];
+        if (expectedParameters.Count == 0)
+        {
+            Assert.Empty(usage.MessageParameters);
+        }
+        else
+        {
+            Assert.Equal(expectedParameters.Count, usage.MessageParameters.Count);
+            Assert.Equal(expectedParameters, usage.MessageParameters);
+        }
+    }
+
+    private static string GenerateActionType(string genericTypes)
+    {
+        if (string.IsNullOrEmpty(genericTypes))
+        {
+            return "Action<ILogger, Exception?>";
+        }
+
+        // Parse the generic types and create the Action type
+        var typeList = genericTypes.Trim('<', '>');
+        if (string.IsNullOrEmpty(typeList))
+        {
+            return "Action<ILogger, Exception?>";
+        }
+
+        var types = typeList.Split(',').Select(t => t.Trim()).ToArray();
+        var actionParams = new List<string> { "ILogger" };
+        actionParams.AddRange(types);
+        actionParams.Add("Exception?");
+
+        return $"Action<{string.Join(", ", actionParams)}>";
+    }
+}


### PR DESCRIPTION
Implements analysis of LoggerMessage.Define method calls to extract logging usage patterns including log levels, event IDs, message templates, and parameter types from generic method signatures.

Extends the logging analysis framework to support compile-time logger message definitions alongside existing runtime logging methods and attribute-based approaches.